### PR TITLE
Bump dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,8 @@ features = ["interpolate", "interpolate-linear", "signal", "signal-window", "sig
 [dev-dependencies]
 hound = "^3.4"
 
+[dev-dependencies.dasp]
+features = ["signal-window-hanning"]
+
 [features]
 nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ num = "0.2"
 num-complex = "0.2"
 rand = "0.3"
 libc = "0.2"
-rustfft = "1.0"
+rustfft = "4.0"
 sample = "0.10"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,17 @@ doctest = false
 crate-type = ["dylib", "rlib"]
 
 [dependencies]
-num = "0.2"
-num-complex = "0.2"
-rand = "0.3"
-libc = "0.2"
-rustfft = "4.0"
-sample = "0.10"
+num = "^0.3"
+rand = "^0.7"
+libc = "^0.2"
+rustfft = "^4.0"
+
+[dependencies.dasp]
+version = "^0.11"
+features = ["interpolate", "interpolate-linear", "signal", "signal-window", "signal-window-rectangle", "window-hanning", "slice"]
 
 [dev-dependencies]
-hound = "2.0"
+hound = "^3.4"
 
 [features]
 nightly = []

--- a/benches/periodic.rs
+++ b/benches/periodic.rs
@@ -10,12 +10,14 @@ use vox_box::periodic::*;
 use vox_box::waves::*;
 
 use sample::{window, ToSampleSlice};
-use sample::signal::Sine;
+use dasp::signal::Sine;
+use dasp::signal::window::Windower;
+use dasp::window::Hanning;
 use std::cmp::Ordering;
 use std::f64::consts::PI;
 
 fn sine(len: usize) -> Vec<f64> {
-    let rate = sample::signal::rate(len as f64).const_hz(1.0);
+    let rate = dasp::signal::rate(len as f64).const_hz(1.0);
     rate.clone().sine().take(len).collect::<Vec<[f64; 1]>>().to_sample_slice().to_vec()
 }
 
@@ -25,18 +27,18 @@ fn sine(len: usize) -> Vec<f64> {
 /// test bench_pitch ... bench:  13,197,760 ns/iter (+/- 2,671,434)
 fn bench_pitch(b: &mut test::Bencher) {
     let exp_freq = 150.0;
-    let mut signal = sample::signal::rate(44100.).const_hz(exp_freq).sine();
+    let mut signal = dasp::signal::rate(44100.).const_hz(exp_freq).sine();
     let vector: Vec<[f64; 1]> = signal.take(4096 + 1).collect();
     let mut maxima: f64 = vector.to_sample_slice().max_amplitude();
 
     let mut chunk_data: Vec<f64> = Vec::with_capacity(4096);
 
     b.iter(|| {
-        for chunk in window::Windower::hanning(&vector[..], 4096, 1024) {
+        for chunk in Windower::hanning(&vector[..], 4096, 1024) {
             for d in chunk.take(4096) {
                 chunk_data.push(d[0]);
             }
-            let pitch = chunk_data.pitch::<window::Hanning>(44100., 0.2, 0.05, maxima, maxima, 0.01, 100., 500.);
+            let pitch = chunk_data.pitch::<Hanning>(44100., 0.2, 0.05, maxima, maxima, 0.01, 100., 500.);
             chunk_data.clear();
         }
     });

--- a/benches/periodic.rs
+++ b/benches/periodic.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "nightly")]
 #![feature(test)]
 
-extern crate sample;
+extern crate dasp;
 extern crate test;
 extern crate vox_box;
 extern crate num;

--- a/examples/formant_extraction/src/main.rs
+++ b/examples/formant_extraction/src/main.rs
@@ -1,5 +1,5 @@
 extern crate hound;
-extern crate sample;
+extern crate dasp;
 extern crate vox_box;
 extern crate num;
 extern crate rustfft;

--- a/examples/formant_extraction/src/main.rs
+++ b/examples/formant_extraction/src/main.rs
@@ -12,9 +12,8 @@ use hound::WavReader;
 use vox_box::spectrum::Resonance;
 use vox_box::periodic::{Hanning, Pitched};
 use vox_box::waves::Filter;
-use sample::{window, ToSampleSliceMut, ToSampleSlice};
-use sample::signal::Signal;
-use sample::interpolate::{Sinc, Converter, Linear};
+use dasp::signal::window::Windower;
+use dasp::slice::ToSampleSlice;
 use num::Complex;
 
 /// Prints the time stamp, then RMS, followed by the center frequency and bandwidth of 5 formants

--- a/examples/pitch_detection.rs
+++ b/examples/pitch_detection.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "valgrind")]
 extern crate alloc_system;
 
-extern crate sample;
+extern crate dasp;
 extern crate vox_box;
 extern crate num;
 

--- a/examples/pitch_detection.rs
+++ b/examples/pitch_detection.rs
@@ -10,19 +10,23 @@ extern crate num;
 use vox_box::periodic::*;
 use vox_box::waves::*;
 
-use sample::{window, Signal, ToSampleSlice};
+use dasp::{Signal, signal};
+use dasp::signal::window::Windower;
+use dasp::window::Hanning;
+
+use dasp::slice::ToSampleSlice;
 
 fn get_pitch() -> Result<(), ()> {
     let exp_freq = 150.0;
-    let signal = sample::signal::rate(44100.).const_hz(exp_freq).sine();
-    let vector: Vec<[f64; 1]> = signal.take(2048 * 1 + 1).collect();
+    let signal = signal::rate(44100.).const_hz(exp_freq).sine();
+    let vector: Vec<f64> = signal.take(2048 * 1 + 1).collect();
     let maxima: f64 = vector.to_sample_slice().max_amplitude();
     let mut pitches_out: Vec<Vec<Pitch<f64>>> = Vec::new();
 
     let mut chunk_data: Vec<f64> = Vec::with_capacity(2048);
-    for chunk in window::Windower::hanning(&vector[..], 2048, 1024) {
+    for chunk in Windower::hanning(&vector[..], 2048, 1024) {
         for d in chunk.take(2048) {
-            chunk_data.push(d[0]);
+            chunk_data.push(d);
         }
         let local_maxima = chunk_data.to_sample_slice().max_amplitude();
         pitches_out.push(analyze_pitch(&chunk_data[..], maxima, local_maxima)?);
@@ -45,6 +49,6 @@ fn main() {
 }
 
 fn analyze_pitch(chunk_data: &[f64], maxima: f64, local_maxima: f64) -> Result<Vec<Pitch<f64>>, ()> {
-    Ok(chunk_data.pitch::<window::Hanning>(44100., 0.2, local_maxima, maxima, 100., 500.))
+    Ok(chunk_data.pitch::<Hanning>(44100., 0.2, local_maxima, maxima, 100., 500.))
 }
 

--- a/src/complex.rs
+++ b/src/complex.rs
@@ -1,8 +1,7 @@
 extern crate num;
-extern crate sample;
+extern crate dasp;
 
-pub use num_complex::*;
-use num::Float;
+use num::{Complex, Float};
 use num::traits::FromPrimitive;
 
 pub trait SquareRoot<T> {
@@ -13,7 +12,7 @@ pub trait SquareRoot<T> {
 impl<T: Float + FromPrimitive> SquareRoot<T> for Complex<T> {
     fn sqrt(&self) -> Complex<T> {
         let (r, theta) = self.to_polar();
-        Complex::<T>::from_polar(&r.sqrt(), &(theta / T::from_f32(2.0f32).unwrap()))
+        Complex::<T>::from_polar(r.sqrt(), theta / T::from_f32(2.0f32).unwrap())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 extern crate num;
-extern crate num_complex;
 extern crate rand;
-extern crate sample;
+extern crate dasp;
 extern crate rustfft;
 
 // Declare local mods
@@ -12,10 +11,11 @@ pub mod spectrum;
 pub mod waves;
 pub mod error;
 
-use sample::{Sample, Signal, signal};
-use sample::conv::Duplex;
-use sample::window::Type;
-use sample::interpolate::{Linear, Converter};
+use dasp::{signal, Sample, Signal};
+use dasp::signal::interpolate::Converter;
+use dasp::interpolate::linear::Linear;
+use dasp::sample::Duplex;
+use dasp::window::{Hanning, Window};
 
 use spectrum::{LPC, Resonance, EstimateFormants};
 use polynomial::Polynomial;
@@ -65,7 +65,7 @@ pub fn find_formants<S>(buf: &mut [S], sample_rate: S, resample_ratio: f64, resa
 
     let len_inv = 1f64 / resampled_len as f64;
     for (idx, s) in resampled_buf.iter_mut().enumerate() {
-        let window = sample::window::Hanning::at_phase(S::from_sample(idx as f64 * len_inv));
+        let window = Hanning::window(S::from_sample(idx as f64 * len_inv));
         *s = *s * window;
     }
 

--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -490,7 +490,7 @@ mod tests {
         let mut maxima: f64 = vector.to_sample_slice().max_amplitude();
         for chunk in Windower::hanning(&vector[..], bin, hop) {
             let chunk_data: Vec<f64> = chunk.take(bin).collect();
-            let pitch = chunk_data.to_sample_slice().pitch::<Hanning>(44100., 0.2, maxima, maxima, 100., 500.);
+            let pitch = chunk_data.to_sample_slice().pitch::<HanningLag>(44100., 0.2, maxima, maxima, 100., 500.);
             println!("pitch: {:?}", pitch);
             assert!((pitch[0].frequency - exp_freq).abs() < 1.0e-2);
         }

--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -458,14 +458,16 @@ mod tests {
     use super::*;
     use super::super::waves::*;
 
-    use sample::{window, Signal, ToSampleSlice};
-    use sample::signal::Sine;
+    use dasp::Signal;
+    use dasp::signal::Sine;
+    use dasp::signal::window::Windower;
+    use dasp::window::Hanning;
     use std::cmp::Ordering;
     use std::f64::consts::PI;
 
     fn sine(len: usize) -> Vec<f64> {
-        let rate = sample::signal::rate(len as f64).const_hz(1.0);
-        rate.clone().sine().take(len).collect::<Vec<[f64; 1]>>().to_sample_slice().to_vec()
+        let rate = dasp::signal::rate(len as f64).const_hz(1.0);
+        rate.clone().sine().take(len).collect::<Vec<f64>>().to_sample_slice().to_vec()
     }
 
     #[test]
@@ -483,12 +485,12 @@ mod tests {
         let bin = 2048;
         let hop = 1024;
 
-        let mut signal = sample::signal::rate(44100.).const_hz(exp_freq).sine();
-        let vector: Vec<[f64; 1]> = signal.take(bin + 1).collect();
+        let mut signal = dasp::signal::rate(44100.).const_hz(exp_freq).sine();
+        let vector: Vec<f64> = signal.take(bin + 1).collect();
         let mut maxima: f64 = vector.to_sample_slice().max_amplitude();
-        for chunk in window::Windower::hanning(&vector[..], bin, hop) {
-            let chunk_data: Vec<[f64; 1]> = chunk.take(bin).collect();
-            let pitch = chunk_data.to_sample_slice().pitch::<window::Hanning>(44100., 0.2, maxima, maxima, 100., 500.);
+        for chunk in Windower::hanning(&vector[..], bin, hop) {
+            let chunk_data: Vec<f64> = chunk.take(bin).collect();
+            let pitch = chunk_data.to_sample_slice().pitch::<Hanning>(44100., 0.2, maxima, maxima, 100., 500.);
             println!("pitch: {:?}", pitch);
             assert!((pitch[0].frequency - exp_freq).abs() < 1.0e-2);
         }

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -454,13 +454,14 @@ mod test {
     use rand::{thread_rng, Rng};
     use waves::*;
     use periodic::*;
-    use sample::{window, Signal, ToSampleSlice};
+    use dasp::Signal;
+    use dasp::slice::ToSampleSlice;
     use num::Complex;
     use polynomial::Polynomial;
 
     fn sine(len: usize) -> Vec<f64> {
-        let rate = sample::signal::rate(len as f64).const_hz(1.0);
-        rate.clone().sine().take(len).collect::<Vec<[f64; 1]>>().to_sample_slice().to_vec()
+        let rate = dasp::signal::rate(len as f64).const_hz(1.0);
+        rate.clone().sine().take(len).collect::<Vec<f64>>().to_sample_slice().to_vec()
     }
 
     #[test]
@@ -493,7 +494,7 @@ mod test {
 
     #[test]
     fn test_sine_resonances_praat() {
-        let sine = sample::signal::rate(44100.).const_hz(440.).sine().take(512).collect::<Vec<[f64; 1]>>().to_sample_slice().to_vec();
+        let sine = dasp::signal::rate(44100.).const_hz(440.).sine().take(512).collect::<Vec<f64>>().to_sample_slice().to_vec();
         let coeffs: Vec<f64> = sine.lpc_praat(4).unwrap();
         println!("coeffs: {:?}", coeffs);
         let complex_coeffs: Vec<Complex<f64>> = [1.].iter().chain(coeffs.iter()).rev().map(|c| Complex::<f64>::new(*c, 0.)).collect();
@@ -584,9 +585,9 @@ mod test {
     #[test]
     fn test_mfcc() {
         let mut rng = thread_rng();
-        let mut vec: Vec<f64> = (0..256).map(|_| rng.gen_range::<f64>(-1., 1.)).collect();
+        let mut vec: Vec<f64> = (0..256).map(|_| rng.gen_range::<f64, f64, f64>(-1., 1.)).collect();
         vec.preemphasis(0.1f64 * 22_050.);
-        let hanning_window: Vec<[f64; 1]> = window::hanning(256).take(256).collect();
+        let hanning_window: Vec<f64> = dasp::signal::window::hanning(256).take(256).collect();
         for (v, w) in vec.iter_mut().zip(hanning_window.to_sample_slice().iter()) {
             *v *= *w;
         }

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -1,5 +1,5 @@
 extern crate num;
-extern crate rustfft as fft;
+extern crate rustfft;
 
 use std::f64::consts::PI;
 use std::default::Default;
@@ -8,6 +8,9 @@ use num::{Complex, Float, ToPrimitive, FromPrimitive};
 use num::traits::{Zero, Signed};
 use std::fmt::Debug;
 use std::cmp::Ordering;
+
+use rustfft::{FFTplanner, FFTnum};
+use rustfft::num_complex::Complex as RustFFTComplex;
 
 use error::*;
 
@@ -405,7 +408,8 @@ impl<T: ?Sized> MFCC<T> for [T]
              FromPrimitive + 
              Into<Complex<T>> + 
              Zero + 
-             Signed
+             Signed +
+             FFTnum
 {
     fn mfcc(&self, num_coeffs: usize, freq_bounds: (f64, f64), sample_rate: f64) -> Vec<T> {
         let mel_range = hz_to_mel(freq_bounds.1) - hz_to_mel(freq_bounds.0);
@@ -413,10 +417,11 @@ impl<T: ?Sized> MFCC<T> for [T]
         let points = (0..(num_coeffs + 2)).map(|i| (i as f64 / num_coeffs as f64) * mel_range + hz_to_mel(freq_bounds.0));
         let bins: Vec<usize> = points.map(|point| ((self.len() + 1) as f64 * mel_to_hz(point) / sample_rate).floor() as usize).collect();
 
-        let mut spectrum = vec![Complex::<T>::from(T::zero()); self.len()];
-        let mut fft = fft::FFT::new(self.len(), false);
-        let signal: Vec<Complex<T>> = self.iter().map(|e| Complex::<T>::from(e)).collect();
-        fft.process(&signal[..], &mut spectrum[..]);
+        let mut spectrum = vec![RustFFTComplex::<T>::from(T::zero()); self.len()];
+
+        let mut fft = FFTplanner::new(false).plan_fft(self.len());
+        let mut signal: Vec<RustFFTComplex<T>> = self.iter().map(|e| RustFFTComplex::<T>::from(e)).collect();
+        fft.process(&mut signal[..], &mut spectrum[..]);
 
         let energy_map = |window: &[usize]| -> T {
             let up = window[1] - window[0];

--- a/src/spectrum.rs
+++ b/src/spectrum.rs
@@ -447,7 +447,7 @@ impl<T: ?Sized> MFCC<T> for [T]
 
 #[cfg(test)]
 mod test {
-    extern crate sample;
+    extern crate dasp;
     extern crate rand;
 
     use super::*;

--- a/src/waves.rs
+++ b/src/waves.rs
@@ -103,12 +103,12 @@ mod tests {
     use super::super::*;
     use super::super::periodic::*;
 
-    use sample::conv::ToSampleSlice;
-    use sample::window::Window;
+    use dasp::slice::ToSampleSlice;
+    use dasp::signal::window::Window;
 
     fn sine(len: usize) -> Vec<f64> {
-        let rate = sample::signal::rate(len as f64).const_hz(1.0);
-        rate.clone().sine().take(len).collect::<Vec<[f64; 1]>>().to_sample_slice().to_vec()
+        let rate = dasp::signal::rate(len as f64).const_hz(1.0);
+        rate.clone().sine().take(len).collect::<Vec<f64>>().to_sample_slice().to_vec()
     }
 
     #[test]
@@ -119,12 +119,12 @@ mod tests {
 
     #[test]
     fn test_window_autocorr() {
-        let lag_window: Window<[f64; 1], HanningLag> = Window::new(16);
-        let data: Vec<[f64; 1]> = lag_window.take(16).collect();
+        let lag_window: Window<f64, HanningLag> = Window::new(16);
+        let data: Vec<f64> = lag_window.take(16).collect();
         println!("window autocorr: {:?}", &data);
-        let window: Window<[f64; 1], Hanning> = Window::new(16);
+        let window: Window<f64, Hanning> = Window::new(16);
         let mut manual: Vec<f64> = {
-            let mut d: Vec<[f64; 1]> = window.take(16).collect();
+            let mut d: Vec<f64> = window.take(16).collect();
             d.to_sample_slice().autocorrelate(16)
         };
         manual.normalize();

--- a/src/waves.rs
+++ b/src/waves.rs
@@ -1,11 +1,11 @@
 extern crate num;
-extern crate sample;
+extern crate dasp;
 
 use std::f64::consts::PI;
 use std::iter::Iterator;
 use std::cmp::Ordering::*;
 
-use sample::{Sample, FloatSample, FromSample};
+use dasp::sample::{Sample, FloatSample, FromSample};
 
 pub trait RMS<S> {
     fn rms(&self) -> S;
@@ -14,7 +14,7 @@ pub trait RMS<S> {
 impl<S: Sample> RMS<S> for [S] {
     fn rms(&self) -> S {
         let sum = self.iter()
-            .fold(S::equilibrium(), |acc, &item: &S| {
+            .fold(S::EQUILIBRIUM, |acc, &item: &S| {
                 acc.add_amp(item.mul_amp(item.to_float_sample()).to_signed_sample())
             });
         (sum.to_float_sample() / (self.len() as f64).to_sample::<S::Float>())
@@ -28,7 +28,7 @@ pub trait Amplitude<S> {
 
 impl<S: Sample> Amplitude<S> for S {
     fn amplitude(self) -> S {
-        if self < S::equilibrium() {
+        if self < S::EQUILIBRIUM {
             self.mul_amp(S::Float::from_sample(-1.0))
         } else {
             self
@@ -67,7 +67,7 @@ pub trait Normalize<S> {
 
 impl<S: Sample> Normalize<S> for [S] {
     fn normalize_with_max(&mut self, max: Option<S>) {
-        let scale_factor: <S as Sample>::Float = <S as Sample>::identity() / 
+        let scale_factor: <S as Sample>::Float = <S as Sample>::IDENTITY /
             max.unwrap_or(self.max_amplitude()).to_float_sample();
         for elem in self.iter_mut() {
             *elem = elem.mul_amp(scale_factor);
@@ -97,7 +97,7 @@ impl<S: Sample + FromSample<f64>> Filter for [S] {
 
 #[cfg(test)]
 mod tests {
-    extern crate sample;
+    extern crate dasp;
 
     use super::*;
     use super::super::*;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -6,7 +6,7 @@ extern crate vox_box;
 use hound::WavReader;
 use vox_box::waves::*;
 use vox_box::spectrum::Resonance;
-use sample::{window, ToFrameSlice, ToSampleSlice};
+use dasp::signal::window::Windower;
 use num::Complex;
 use std::i32;
 
@@ -62,13 +62,13 @@ fn test_formant_calculation() {
     let mut frame_buffer: Vec<f64> = Vec::with_capacity(bin);
     let mut powers: Vec<f64> = Vec::new();
 
-    let sample_frames: &[[f64; 1]] = sample::slice::to_frame_slice(&samples[..]).unwrap();
+    let sample_frames: &[[f64; 1]] = dasp::slice::to_frame_slice(&samples[..]).unwrap();
     let mut resampled_buf = vec![0f64; resampled_len];
 
     let mut work = vec![0f64; vox_box::find_formants_real_work_size(resampled_len, n_coeffs)];
     let mut complex_work = vec![Complex::new(0f64, 0.); vox_box::find_formants_complex_work_size(n_coeffs)];
 
-    for frame in window::Windower::rectangle(sample_frames, bin, hop) {
+    for frame in Windower::rectangle(sample_frames, bin, hop) {
         for s in frame.take(bin) { 
             frame_buffer.push(s[0]); 
         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,6 @@
 extern crate num;
 extern crate hound;
-extern crate sample;
+extern crate dasp;
 extern crate vox_box;
 
 use hound::WavReader;


### PR DESCRIPTION
Hi, I'm interested in learning some Rust and some voice processing, so this was a natural repo to look at!

I've had a first pass at bringing dependencies up to date. The biggest change is sample 0.10 -> dasp 0.11

A couple of things I wanted to specifically check with you:
- in dasp (previously "sample") `Window<S, W>::new` now requires S of type f64, so pitch() is now limited to f64 samples. This works fine for your data, but presumably the whole point of having this generic library is that these functions can be applied to any Sample data type. https://docs.rs/dasp_signal/0.11.0/src/dasp_signal/window/mod.rs.html#79
- you had a number of Windows with Sample type [f64; 1], rather than a straight f64. Switching to f64 was one way to resolve type issues after updating to dasp - is there a need for the single-value array type?
- I was confused as to why you implemented a Lag type for the Hanning Window, rather than pass the new lag type directly to pitch. Perhaps you had some other functionality in mind? Rather than the previous `Type`, there are now two `Window` types, one of which functions similarly to `Type` (they even import it as WindowType internally https://docs.rs/dasp_signal/0.11.0/src/dasp_signal/window/mod.rs.html#7), which is what I've done with HanningLag. I might be able to reinstate the previous arrangement though - would there be benefit to that? I'm guessing you had some direction you were considering exploring.

I'm happy to go through and try to sort any warnings too, but thought perhaps a separate PR after this might be appropriate.
Also happy to switch the examples around to a more standard setup so they can be run as `cargo run --example example-name` if that would appeal.